### PR TITLE
Remove contributing section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,6 @@ Provide instructions on how to use and integrate the library into a project.
 
 If there's some special peices for testing (ie Mocks) explain those here as well.
 
-## Contributors
-
-We'd love for you to contribute to our open source projects. Before we can accept your contributions, we kindly ask you to sign our [Uber Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform).
-
-- If you **find a bug**, open an issue or submit a fix via a pull request.
-- If you **have a feature request**, open an issue or submit an implementation via a pull request
-- If you **want to contribute**, submit a pull request.
-
 ## License
 
     Copyright (C) 2017 Uber Technologies


### PR DESCRIPTION
This is just duplicating what is already covered by the `CONTRIBUTING.md` file does (and is surfaced by github). The CLA bot also handles the CLA stuff on PRs automatically.

CC @tyvsmith